### PR TITLE
Add google() to buildscript repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
         maven { url "https://maven.google.com" }
     }


### PR DESCRIPTION
First of all thank you for this library, awesome work, congratz ❤️ 

I'm not sure why, and I'm not a gradle expert but my app wont build unless I add `google()` to the `build.gradle` file.

Without the changes from this PR I get the following error when running `react-native run-android`:
```
* What went wrong:
A problem occurred configuring project ':react-native-file-selector'.
> Could not resolve all files for configuration ':react-native-file-selector:classpath'.
   > Could not find intellij-core.jar (com.android.tools.external.com-intellij:intellij-core:26.0.1).
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/external/com-intellij/intellij-core/26.0.1/intellij-core-26.0.1.jar
```