### PR TITLE
Fix podspec missing home attr

### DIFF
--- a/ios/RNFileSelector.podspec
+++ b/ios/RNFileSelector.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNFileSelector
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/prscX/react-native-file-selector"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
This change fixes the following error:
```
Fetching podspec for `RNFileSelector` from `../node_modules/react-native-file-selector/ios`
[!] The `RNFileSelector` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```